### PR TITLE
chore(dprint): Exclude Eleventy .md files from formatting

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -22,6 +22,7 @@
   "excludes": [
     "dist/",
     "node_modules/",
+    "src/site/**/*.md",
     "*-lock.json"
   ],
   "plugins": [


### PR DESCRIPTION
It doesn't know that they are mixed Nunjucks and Markdown files, so it ends up misformatting them.