### PR TITLE
chore: Update lint-staged and stylelint config

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["stylelint-config-standard-scss"],
+  "extends": ["stylelint-config-standard-scss", "stylelint-config-prettier-scss"],
   "rules": {
     "scss/dollar-variable-pattern": null,
     "selector-class-pattern": null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "serve": "^14.1.2",
         "shx": "^0.3.4",
         "stylelint": "^14.16.1",
+        "stylelint-config-prettier-scss": "^0.0.1",
         "stylelint-config-standard-scss": "^6.1.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4",
@@ -11666,6 +11667,41 @@
         "url": "https://opencollective.com/stylelint"
       }
     },
+    "node_modules/stylelint-config-prettier": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
+      "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
+      "dev": true,
+      "bin": {
+        "stylelint-config-prettier": "bin/check.js",
+        "stylelint-config-prettier-check": "bin/check.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "stylelint": ">=11.0.0"
+      }
+    },
+    "node_modules/stylelint-config-prettier-scss": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier-scss/-/stylelint-config-prettier-scss-0.0.1.tgz",
+      "integrity": "sha512-lBAYG9xYOh2LeWEPC/64xeUxwOTnQ8nDyBijQoWoJb10/bMGrUwnokpt8jegGck2Vbtxh6XGwH63z5qBcVHreQ==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-prettier": ">=9.0.3"
+      },
+      "bin": {
+        "stylelint-config-prettier-scss": "bin/check.js",
+        "stylelint-config-prettier-scss-check": "bin/check.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "stylelint": ">=11.0.0"
+      }
+    },
     "node_modules/stylelint-config-recommended": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
@@ -22162,6 +22198,22 @@
           "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
           "dev": true
         }
+      }
+    },
+    "stylelint-config-prettier": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
+      "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
+      "dev": true,
+      "requires": {}
+    },
+    "stylelint-config-prettier-scss": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier-scss/-/stylelint-config-prettier-scss-0.0.1.tgz",
+      "integrity": "sha512-lBAYG9xYOh2LeWEPC/64xeUxwOTnQ8nDyBijQoWoJb10/bMGrUwnokpt8jegGck2Vbtxh6XGwH63z5qBcVHreQ==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-prettier": ">=9.0.3"
       }
     },
     "stylelint-config-recommended": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,10 @@
       "dprint fmt",
       "eslint --max-warnings 0"
     ],
-    "*.{md,scss,yaml,yml}": [
+    "*.{scss,yaml,yml}": [
+      "dprint fmt"
+    ],
+    "!(src/site/**/*)*.md": [
       "dprint fmt"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "serve": "^14.1.2",
     "shx": "^0.3.4",
     "stylelint": "^14.16.1",
+    "stylelint-config-prettier-scss": "^0.0.1",
     "stylelint-config-standard-scss": "^6.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
@@ -89,7 +90,11 @@
       "dprint fmt",
       "eslint --max-warnings 0"
     ],
-    "*.{scss,yaml,yml}": [
+    "*.{scss}": [
+      "dprint fmt",
+      "stylelint"
+    ],
+    "*.{yaml,yml}": [
       "dprint fmt"
     ],
     "!(src/site/**/*)*.md": [


### PR DESCRIPTION
This: 

- ignores Eleventy .md files in lint-staged for the same reason as in #20 
- adds some Prettier exceptions to stylelint to stop them conflicting with each other
- makes lint-staged run stylelint