### PR TITLE
ci: Fix error pushing tag during release

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -4,6 +4,7 @@ const commitlintConfig = require('./commitlint.config')
 module.exports = {
   git: {
     commit: false,
+    push: false,
     requireBranch: 'main',
     requireCommits: true,
     // eslint-disable-next-line no-template-curly-in-string
@@ -15,6 +16,10 @@ module.exports = {
     releaseName: 'v${version}',
   },
   npm: false,
+  hooks: {
+    // eslint-disable-next-line no-template-curly-in-string
+    'before:github:release': 'git push origin v${version}',
+  },
   plugins: {
     '@release-it/conventional-changelog': {
       parserOpts: commitlintConfig.parserPreset.parserOpts,


### PR DESCRIPTION
This resolves a problem where a release would fail if two PRs were merged in quick succession.

The failure was due to `git push --follow-tags` failing on the release build for the first PR due it the commit being behind the latest `main`.

This instead makes release-it push only the relevant tag. It was tested in https://github.com/jpveooys/github-actions-testing-v2.