### PR TITLE
fix(nginx): Use relative redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY --from=builder /app-build/dist "${HOME}"
 
 ADD nginx/startup.sh /opt/app-root/startup.sh
 ADD nginx/logging.conf "${NGINX_CONFIGURATION_PATH}"
+ADD nginx/misc-http-section.conf "${NGINX_CONFIGURATION_PATH}"
 ADD nginx/owasp-http-section.conf "${NGINX_CONFIGURATION_PATH}"
 ADD nginx/owasp-server-section.conf "${NGINX_DEFAULT_CONF_PATH}"
 

--- a/nginx/misc-http-section.conf
+++ b/nginx/misc-http-section.conf
@@ -1,0 +1,1 @@
+absolute_redirect off;


### PR DESCRIPTION
This configures nginx to use relative redirects instead of absolute ones, which sidesteps problems about knowing the correct protocol and port to redirect to (which nginx won't necessarily know).

I didn't go for `port_in_redirect off;` as:

- it would break redirects locally
- it wouldn't fix nginx redirecting to `http://` instead of `https://` in D2S