### PR TITLE
ci: Shard Playwright tests

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -71,13 +71,17 @@ jobs:
           echo "version=$(scripts/get-playwright-version.sh)" >> "$GITHUB_OUTPUT"
 
   test-e2e:
-    name: Run e2e tests
+    name: Run e2e tests (${{ matrix.shard }}/${{ matrix.total_shards }})
     runs-on: ubuntu-latest
     needs:
       - read-playwright-version
     container:
       image: mcr.microsoft.com/playwright:${{ needs.read-playwright-version.outputs.version }}-jammy
       options: --user 1001
+    strategy:
+      matrix:
+        shard: [1, 2]
+        total_shards: [2]
     steps:
       - name: Git clone repository
         uses: actions/checkout@v3
@@ -89,22 +93,26 @@ jobs:
         run: npm run build
 
       - name: Run e2e tests
-        run: npm run test:e2e
+        run: npm run test:e2e -- --shard ${{ matrix.shard }}/${{ matrix.total_shards }}
 
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: e2e-test-results
+          name: e2e-test-results-${{ matrix.shard }}
           path: e2e/output
 
   test-visual-regression:
-    name: Run visual regression tests
+    name: Run visual regression tests (${{ matrix.shard }}/${{ matrix.total_shards }})
     runs-on: ubuntu-latest
     needs:
       - read-playwright-version
     container:
       image: mcr.microsoft.com/playwright:${{ needs.read-playwright-version.outputs.version }}-jammy
       options: --user 1001
+    strategy:
+      matrix:
+        shard: [1, 2]
+        total_shards: [2]
     steps:
       - name: Git clone repository
         uses: actions/checkout@v3
@@ -116,12 +124,12 @@ jobs:
         run: npm run build
 
       - name: Run visual regression tests
-        run: npm run test:visual:native
+        run: npm run test:visual:native -- --shard ${{ matrix.shard }}/${{ matrix.total_shards }}
 
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: visual-regression-test-results
+          name: visual-regression-test-results-${{ matrix.shard }}
           path: e2e/output
 
   audit-dependencies:


### PR DESCRIPTION
This updates both the end-to-end and visual regression tests to use two shards on GitHub Actions, as they're now taking a few minutes.

Rough comparison of before and after:

# Before

![image](https://user-images.githubusercontent.com/66470099/219640208-f0c03c73-1084-498b-b645-e0edf982ae70.png)

# After

![image](https://user-images.githubusercontent.com/66470099/219640302-f0202ca7-e6f2-4988-96e3-a021ae5f4add.png)
