### PR TITLE
fix: Add cache control for static files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,7 @@ ADD nginx/logging.conf "${NGINX_CONFIGURATION_PATH}"
 ADD nginx/misc-http-section.conf "${NGINX_CONFIGURATION_PATH}"
 ADD nginx/owasp-http-section.conf "${NGINX_CONFIGURATION_PATH}"
 ADD nginx/owasp-server-section.conf "${NGINX_DEFAULT_CONF_PATH}"
+ADD nginx/assets-server-section.conf "${NGINX_DEFAULT_CONF_PATH}"
+COPY nginx/common-server-section.conf "${NGINX_APP_ROOT}/etc/include/"
 
 CMD /opt/app-root/startup.sh

--- a/nginx/assets-server-section.conf
+++ b/nginx/assets-server-section.conf
@@ -1,0 +1,4 @@
+location ~ \.(css|js|png|svg|json)$ {
+    add_header Cache-Control "max-age=3600, public";
+    include '/opt/app-root/etc/include/common-server-section.conf';
+}

--- a/nginx/common-server-section.conf
+++ b/nginx/common-server-section.conf
@@ -1,0 +1,4 @@
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header X-Content-Type-Options nosniff always;
+add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'self'; form-action 'self'; base-uri 'self'; manifest-src 'self'; script-src 'self' 'unsafe-inline' *.service.mod.gov.uk *.dev.service.mod.gov.uk; frame-src 'self' *.service.mod.gov.uk *.dev.service.mod.gov.uk; style-src 'self'; connect-src 'self' *.service.mod.gov.uk *.dev.service.mod.gov.uk; img-src 'self';" always;
+add_header Permissions-Policy "accelerometer=(self), autoplay=(self), camera=(self), encrypted-media=(self), fullscreen=(self), geolocation=(self), gyroscope=(self), magnetometer=(self), midi=(self), payment=(self), picture-in-picture=(self), sync-xhr=(self), usb=(self)" always;

--- a/nginx/owasp-server-section.conf
+++ b/nginx/owasp-server-section.conf
@@ -1,5 +1,2 @@
-add_header X-Content-Type-Options nosniff always;
-add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Cache-Control "max-age=0, must-revalidate, no-cache, no-store, private" always;
-add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'self'; form-action 'self'; base-uri 'self'; manifest-src 'self'; script-src 'self' 'unsafe-inline' *.service.mod.gov.uk *.dev.service.mod.gov.uk; frame-src 'self' *.service.mod.gov.uk *.dev.service.mod.gov.uk; style-src 'self'; connect-src 'self' *.service.mod.gov.uk *.dev.service.mod.gov.uk; img-src 'self';" always;
-add_header Permissions-Policy "accelerometer=(self), autoplay=(self), camera=(self), encrypted-media=(self), fullscreen=(self), geolocation=(self), gyroscope=(self), magnetometer=(self), midi=(self), payment=(self), picture-in-picture=(self), sync-xhr=(self), usb=(self)" always;
+include '/opt/app-root/etc/include/common-server-section.conf';


### PR DESCRIPTION
This PR adds cache control for 1 hour only to deal with iframe issues. 
I have not made it longer because we have no versioning on the js files yet. e.g `main.3edfsd.js`  
I have also left out the `immutable`  directive for the same reason. 

```
Cache-Control: max-age=3600, public
```

To test I built the image locally and 
`podman build -f Dockerfile -t moduk-guidance`
run the container
`podman run --rm -e IS_PROD=true -d -p 8080:8080 localhost/moduk-guidance:latest` 