### PR TITLE
build(container): Don't download Playwright browsers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 COPY . /app-build
 WORKDIR /app-build
 
-RUN npm ci
+RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
 RUN npm run build
 
 # Copy to the RedHat Nginx image


### PR DESCRIPTION
This makes a simple change to the Dockerfile to not download Playwright browsers when `npm ci` is run, as an easy way to speed up building the container image.