### PR TITLE
feat(component-preview): Add minimum size when resizing example

### DIFF
--- a/e2e/tests/component-preview.spec.ts
+++ b/e2e/tests/component-preview.spec.ts
@@ -24,6 +24,31 @@ test.describe('component preview', () => {
     )
   })
 
+  test('does not allow resizing smaller than 230px by 60px', async ({ browserName, page }) => {
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=680823
+    test.skip(browserName === 'firefox', 'Firefox does not support resizable iframes')
+
+    const componentPreview = page.locator('.guidance-component-preview__preview')
+    const boundingBox = await componentPreview.boundingBox()
+
+    if (!boundingBox) {
+      throw new Error('boundingBox was null')
+    }
+
+    const boxRight = boundingBox.x + boundingBox.width
+    const boxBottom = boundingBox.y + boundingBox.height
+
+    await page.mouse.move(boxRight - 1, boxBottom - 1)
+    await page.mouse.down()
+    await page.mouse.move(0, 0)
+    await page.mouse.up()
+
+    const resizedBoundingBox = await componentPreview.boundingBox()
+
+    expect(resizedBoundingBox?.width).toBe(230)
+    expect(resizedBoundingBox?.height).toBe(60)
+  })
+
   test.describe('when the HTML tab is clicked', () => {
     test.beforeEach(async ({ page, tabRole }) => {
       const htmlTabButton = page.getByRole(tabRole, { name: 'HTML' })

--- a/src/site/_includes/components/component-preview/index.scss
+++ b/src/site/_includes/components/component-preview/index.scss
@@ -48,6 +48,8 @@ $border-value: 1px solid moduk.$govuk-border-colour;
   background-color: moduk.govuk-colour('white');
   overflow: hidden;
   resize: both;
+  min-height: 60px;
+  min-width: 230px;
   max-width: 100%;
   outline: $border-value;
 }


### PR DESCRIPTION
This adds a minimum width and height to component examples, which restricts how small they can be resized.