### PR TITLE
test(visual-regression): Allow container volume args to be overridden

### DIFF
--- a/scripts/run-playwright-container.sh
+++ b/scripts/run-playwright-container.sh
@@ -3,5 +3,6 @@ set -e
 
 CONTAINER_RUNNER="${CONTAINER_RUNNER:-podman}"
 PLAYWRIGHT_VERSION=$(scripts/get-playwright-version.sh)
+VOLUME_ARGS=${PLAYWRIGHT_CONTAINER_VOLUME_ARGS:--v "$(pwd)":/work/ -v /work/node_modules}
 
-$CONTAINER_RUNNER run --rm -v "$(pwd)":/work/ -v /work/node_modules -w /work/ -it -e CI mcr.microsoft.com/playwright:"${PLAYWRIGHT_VERSION}-jammy" "$@"
+$CONTAINER_RUNNER run --rm $VOLUME_ARGS -w /work/ -it -e CI mcr.microsoft.com/playwright:"${PLAYWRIGHT_VERSION}-jammy" "$@"


### PR DESCRIPTION
This updates `scripts/run-playwright-container.sh` so that an overlay file system is used when mounting the current directory (including node_modules). This means `node_modules` starts off the same as the host, but any changes written to it in the container are temporary and limited to the container itself.

The `e2e` directory is mounted normally so that reports and screenshots are written to the host.

This speeds up the `npm install` part of `npm run test:visual` for me (on Ubuntu).

@adamledwards Could you check if this works okay for you?