### PR TITLE
build(container): Avoid reinstalling npm packages when files change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@
 FROM registry.access.redhat.com/ubi9/nodejs-18:latest AS builder
 
 USER root
-
-COPY . /app-build
 WORKDIR /app-build
 
+COPY package.json /app-build/
+COPY package-lock.json /app-build/
 RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
+
+COPY . /app-build
 RUN npm run build
 
 # Copy to the RedHat Nginx image


### PR DESCRIPTION
This makes a few small tweaks to the Dockerfile so that `npm ci` is only rerun if `package.json` or `package-lock.json` has changed.