### PR TITLE
docs(contributing): Correct title and update commit types

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to MOD.UK Frontend
+# Contributing to this repository
 
 ## Branching strategy
 
@@ -62,6 +62,7 @@ type(scope?): Subject
 - fix
 - perf
 - refactor
+- release
 - revert
 - style
 - test


### PR DESCRIPTION
This corrects the title of the contributing docs and adds a commit type that wasn't listed.