### PR TITLE
deps-dev: Update Playwright to version 1.32.3

### DIFF
--- a/e2e/tests/cookie-banner.spec.ts
+++ b/e2e/tests/cookie-banner.spec.ts
@@ -47,7 +47,6 @@ test.describe('cookie banner', () => {
 
       test('set the cookie preference to the correct value', async ({ browserName, page }) => {
         test.skip(browserName === 'webkit', 'WebKit does not let you set Secure cookies on localhost')
-        // @ts-expect-error See https://github.com/microsoft/playwright/issues/21453
         expect(await page.evaluate(() => document.cookie)).toMatch(`${cookiePreferenceKey}=1`)
       })
 
@@ -74,7 +73,6 @@ test.describe('cookie banner', () => {
 
       test('set the cookie preference to the correct value', async ({ browserName, page }) => {
         test.skip(browserName === 'webkit', 'WebKit does not let you set Secure cookies on localhost')
-        // @ts-expect-error See https://github.com/microsoft/playwright/issues/21453
         expect(await page.evaluate(() => document.cookie)).toMatch(`${cookiePreferenceKey}=0`)
       })
 

--- a/e2e/tests/cookie-settings.spec.ts
+++ b/e2e/tests/cookie-settings.spec.ts
@@ -24,7 +24,6 @@ const testOptions = () => {
 
     test('cookie preference is set to the correct value', async ({ browserName, page }) => {
       test.skip(browserName === 'webkit', 'WebKit does not let you set Secure cookies on localhost')
-      // @ts-expect-error See https://github.com/microsoft/playwright/issues/21453
       expect(await page.evaluate(() => document.cookie)).toMatch(`${cookiePreferenceKey}=1`)
     })
 
@@ -51,7 +50,6 @@ const testOptions = () => {
 
     test('cookie preference is set to the correct value', async ({ browserName, page }) => {
       test.skip(browserName === 'webkit', 'WebKit does not let you set Secure cookies on localhost')
-      // @ts-expect-error See https://github.com/microsoft/playwright/issues/21453
       expect(await page.evaluate(() => document.cookie)).toMatch(`${cookiePreferenceKey}=0`)
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/preset-typescript": "^7.21.4",
         "@commitlint/cli": "^17.5.1",
         "@commitlint/config-conventional": "^17.6.1",
-        "@playwright/test": "^1.31.2",
+        "@playwright/test": "^1.32.3",
         "@release-it/conventional-changelog": "^5.1.1",
         "@testing-library/dom": "^9.2.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -3206,13 +3206,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
+      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.31.2"
+        "playwright-core": "1.32.3"
       },
       "bin": {
         "playwright": "cli.js"
@@ -12588,14 +12588,14 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.31.2.tgz",
-      "integrity": "sha512-jpC47n2PKQNtzB7clmBuWh6ftBRS/Bt5EGLigJ9k2QAKcNeYXZkEaDH5gmvb6+AbcE0DO6GnXdbl9ogG6Eh+og==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.32.3.tgz",
+      "integrity": "sha512-h/ylpgoj6l/EjkfUDyx8cdOlfzC96itPpPe8BXacFkqpw/YsuxkpPyVbzEq4jw+bAJh5FLgh31Ljg2cR6HV3uw==",
       "dev": true,
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
-        "playwright-core": "1.31.2"
+        "playwright-core": "1.32.3"
       },
       "bin": {
         "playwright": "cli.js"
@@ -12605,9 +12605,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
+      "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/preset-typescript": "^7.21.4",
     "@commitlint/cli": "^17.5.1",
     "@commitlint/config-conventional": "^17.6.1",
-    "@playwright/test": "^1.31.2",
+    "@playwright/test": "^1.32.3",
     "@release-it/conventional-changelog": "^5.1.1",
     "@testing-library/dom": "^9.2.0",
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
This updates Playwright to the latest version. That includes removing some `@ts-expect-error`s that are no longer needed (and now causing linter errors).