### PR TITLE
feat(examples): Add React code snippets

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -51,6 +51,10 @@ module.exports = (config) => {
   })
   config.setLibrary('njk', nunjucksEnv)
 
+  config.addNunjucksGlobal('flags', {
+    showReactCodeSnippets: (process.env.SHOW_REACT_CODE_SNIPPETS ?? '').toLowerCase() === 'true',
+  })
+
   const markdownIt = new MarkdownIt()
   config.addFilter('markdown', (markdown) => markdown && new SafeString(markdownIt.render(markdown)))
 
@@ -88,6 +92,16 @@ module.exports = (config) => {
       }
     }
     throw new Error('readTemplate tag: unexpectedly reached end of template include directories')
+  })
+
+  config.addShortcode('readReactExample', (componentName, exampleName) => {
+    try {
+      const examplePath = require.resolve(`@moduk/frontend/src/react/${componentName}/__examples__/${exampleName}.tsx`)
+      const code = readFileSync(examplePath, 'utf8')
+      return prettier.format(code, { parser: 'typescript' })
+    } catch {
+      return ''
+    }
   })
 
   config.addShortcode(

--- a/src/site/_includes/components/component-preview/macro.njk
+++ b/src/site/_includes/components/component-preview/macro.njk
@@ -7,6 +7,11 @@
 {% macro guidanceComponentPreview(params) -%}
 
 {%- set exampleTemplatePath = "moduk/components/" + params.componentName + "/__examples__/" + params.exampleName + ".njk" -%}
+
+{% set reactExampleCode -%}
+{% readReactExample params.componentName, params.exampleName -%}
+{% endset -%}
+
 {%- if params.idSuffix -%}
   {%- set idSuffix = "--" + params.idSuffix -%}
 {%- else -%}
@@ -49,6 +54,32 @@
 {% endcall -%}
 {% endset -%}
 
+{% set tabs = [{
+  label: "HTML",
+  contents: htmlTabContents | safe,
+  panelId: idPrefix + "--html"
+}, {
+  label: "Nunjucks",
+  contents: nunjucksTabContents | safe,
+  panelId: idPrefix + "--nunjucks"
+}] -%}
+
+{% if flags.showReactCodeSnippets and reactExampleCode -%}
+
+{% set reactTabContents %}
+{% call guidanceCodeSnippet({ language: "tsx" }) -%}
+{{ reactExampleCode | safe -}}
+{% endcall -%}
+{% endset -%}
+
+{% set tabs = (tabs.push({
+  label: "React",
+  contents: reactTabContents | safe,
+  panelId: idPrefix + "--tsx"
+}), tabs) -%}
+
+{% endif -%}
+
 <div class="guidance-component-preview js-guidance-component-preview">
   <div class="guidance-component-preview__toolbar">
     <a href="/components/{{ params.componentName }}/preview/{{ params.exampleName }}/" class="govuk-link moduk-link--maroon" target="_blank">
@@ -63,15 +94,7 @@
     </div>
   </div>
   {{ guidanceComponentPreviewTabs({
-    tabs: [{
-      label: "HTML",
-      contents: htmlTabContents | safe,
-      panelId: idPrefix + "--html"
-    }, {
-     label: "Nunjucks",
-     contents: nunjucksTabContents | safe,
-     panelId: idPrefix + "--nunjucks"
-   }]
+    tabs: tabs
   }) }}
 </div>
 {%- endmacro %}


### PR DESCRIPTION
This adds a React tab to examples for supported components containing a code snippet.

The code for the snippet is imported from the `@moduk/frontend` package and run through Prettier to reduce the line length.

If a matching React example is not found, the React tab is hidden.

Note: This shouldn't be merged this until the React components are actually ready for use.
