### PR TITLE
ci(e2e): Merge sharded Playwright reports

### DIFF
--- a/.github/actions/merge-playwright-reports/action.yml
+++ b/.github/actions/merge-playwright-reports/action.yml
@@ -1,0 +1,27 @@
+name: Merge sharded Playwright blob reports
+description: Merges sharded Playwright blob reports
+inputs:
+  input-artifact:
+    required: true
+    description: Name of the artefact containing blob reports
+  output-artifact:
+    required: true
+    description: Name of the artefact to save the HTML report as
+runs:
+  using: composite
+  steps:
+    - name: Download blob reports
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.input-artifact }}
+        path: blob-reports
+
+    - name: Merge reports
+      shell: bash
+      run: npm exec --no -- playwright merge-reports --reporter html blob-reports
+
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: ${{ inputs.output-artifact }}
+        path: playwright-report

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -56,11 +56,11 @@ jobs:
       - name: Run unit tests
         run: npm run test
 
-  read-playwright-version:
-    name: Read Playwright version
+  determine-playwright-image:
+    name: Determine Playwright container image
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.read-version.outputs.version }}
+      container-image: mcr.microsoft.com/playwright:${{ steps.read-version.outputs.version }}-jammy
     steps:
       - name: Git clone repository
         uses: actions/checkout@v4
@@ -74,9 +74,9 @@ jobs:
     name: Run e2e tests (${{ matrix.shard }}/${{ matrix.total_shards }})
     runs-on: ubuntu-latest
     needs:
-      - read-playwright-version
+      - determine-playwright-image
     container:
-      image: mcr.microsoft.com/playwright:${{ needs.read-playwright-version.outputs.version }}-jammy
+      image: ${{ needs.determine-playwright-image.outputs.container-image }}
       options: --user 1001
     strategy:
       matrix:
@@ -98,16 +98,37 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: e2e-test-results-${{ matrix.shard }}
-          path: e2e/output
+          name: e2e-blob-reports
+          path: blob-report
+          retention-days: 1
+
+  merge-e2e-reports:
+    name: Merge e2e test reports
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - determine-playwright-image
+      - test-e2e
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v4
+
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
+
+      - name: Merge reports
+        uses: ./.github/actions/merge-playwright-reports
+        with:
+          input-artifact: e2e-blob-reports
+          output-artifact: e2e-html-report
 
   test-visual-regression:
     name: Run visual regression tests (${{ matrix.shard }}/${{ matrix.total_shards }})
     runs-on: ubuntu-latest
     needs:
-      - read-playwright-version
+      - determine-playwright-image
     container:
-      image: mcr.microsoft.com/playwright:${{ needs.read-playwright-version.outputs.version }}-jammy
+      image: ${{ needs.determine-playwright-image.outputs.container-image }}
       options: --user 1001
     strategy:
       matrix:
@@ -129,8 +150,29 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: visual-regression-test-results-${{ matrix.shard }}
-          path: e2e/output
+          name: visual-regression-blob-reports
+          path: blob-report
+          retention-days: 1
+
+  merge-visual-regression-reports:
+    name: Merge visual regression reports
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - determine-playwright-image
+      - test-visual-regression
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v4
+
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
+
+      - name: Merge reports
+        uses: ./.github/actions/merge-playwright-reports
+        with:
+          input-artifact: visual-regression-blob-reports
+          output-artifact: visual-regression-html-report
 
   build-and-test-container:
     name: Build and test container

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ dist
 .tern-port
 
 /e2e/output/
+/blob-report/
 
 # Editor configs 
 .vscode/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,10 +76,12 @@ const config: PlaywrightTestConfig = {
       },
     },
   ],
-  reporter: [
-    [process.env.CI ? 'github' : 'line'],
-    ['html', { outputFolder: './e2e/output/html/', open: 'never' }],
-  ],
+  reporter: process.env.CI
+    ? [['blob'], ['github']]
+    : [
+      ['line'],
+      ['html', { outputFolder: './e2e/output/html/', open: 'never' }],
+    ],
   retries: process.env.CI ? 1 : 0,
   snapshotPathTemplate: '{testDir}/__screenshots__/{testFilePath}/{arg}--{projectName}{ext}',
   testDir: './e2e/tests',


### PR DESCRIPTION
This updates the GitHub Actions workflow to [merge the reports from each Playwright shard](https://playwright.dev/docs/test-sharding#merging-reports-from-multiple-shards), in line with https://github.com/defencedigital/moduk-frontend/pull/354.