### PR TITLE
fix: Correct path to Safari mask icon

### DIFF
--- a/src/site/_includes/layouts/_base.njk
+++ b/src/site/_includes/layouts/_base.njk
@@ -40,7 +40,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/icon-32.png">
   <link rel="icon" type="image/svg+xml" href="/assets/images/icon.svg">
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/icon-180.png">
-  <link rel="mask-icon" href="/assets/icon-safari-mask.svg" color="#532A45">
+  <link rel="mask-icon" href="/assets/images/icon-safari-mask.svg" color="#532A45">
   <link rel="manifest" href="/manifest.json">
   <link rel="stylesheet" href="{{ "/index.scss" | revvedOutput }}">
   {% if vars.googleTagId %}


### PR DESCRIPTION
The path to the mask icon for Safari was incorrect in the relevant `<link>` element.