### PR TITLE
fix: Improve high contrast mode

### DIFF
--- a/src/site/_includes/components/navigation/index.scss
+++ b/src/site/_includes/components/navigation/index.scss
@@ -16,6 +16,23 @@ $navigation-height: 50px;
 
 .guidance-navigation {
   background-color: moduk.govuk-colour('light-grey');
+  border-bottom: 1px solid moduk.govuk-colour('mid-grey');
+
+  @include moduk.govuk-media-query($from: tablet) {
+    border-top: 1px solid moduk.govuk-colour('mid-grey');
+  }
+
+  @media not (prefers-contrast) {
+    border: none;
+  }
+}
+
+.moduk--has-hero .guidance-navigation {
+  border-bottom-color: moduk.moduk-colour('dark-purple');
+
+  @media not (prefers-contrast) {
+    border: none;
+  }
 }
 
 .guidance-navigation__list {
@@ -61,20 +78,16 @@ $navigation-height: 50px;
 
   &::after {
     content: '';
+    pointer-events: none;
     position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
-    width: $border-width;
-    background-color: moduk.$moduk-brand-colour;
+    inset: 0;
+    border-left: $border-width solid moduk.$moduk-brand-colour;
   }
 
   @include moduk.govuk-media-query($from: tablet) {
     &::after {
-      top: auto;
-      bottom: 0;
-      width: 100%;
-      height: $border-width;
+      border-left: none;
+      border-bottom: $border-width solid moduk.$moduk-brand-colour;
     }
   }
 }
@@ -142,19 +155,14 @@ $navigation-height: 50px;
       &::after {
         content: '';
         position: absolute;
-        left: 0;
-        top: 0;
-        height: 100%;
-        width: $border-width;
-        background-color: moduk.moduk-colour('maroon');
+        inset: 0;
+        border-left: $border-width solid moduk.$moduk-brand-colour;
       }
 
       @include moduk.govuk-media-query($from: tablet) {
         &::after {
-          top: auto;
-          bottom: 0;
-          width: 100%;
-          height: $border-width;
+          border-left: none;
+          border-bottom: $border-width solid moduk.$moduk-brand-colour;
         }
       }
     }

--- a/src/site/_includes/components/phase-banner/index.scss
+++ b/src/site/_includes/components/phase-banner/index.scss
@@ -6,9 +6,14 @@
   }
 }
 
-.moduk--primary-nav-expanded,
-.moduk--has-hero {
-  .govuk-phase-banner.guidance-phase-banner {
+.moduk--has-hero .govuk-phase-banner.guidance-phase-banner {
+  @media not (prefers-contrast) {
+    border-bottom: none;
+  }
+}
+
+.moduk--primary-nav-expanded .govuk-phase-banner.guidance-phase-banner {
+  @media not (prefers-contrast) {
     border-bottom: none;
   }
 }


### PR DESCRIPTION
This adds some some additional borders to the primary navigation and phase banner that were missing when high contrast mode is active.

# Before

![Screenshot 2023-09-19 074124](https://github.com/defencedigital/moduk-frontend-guidance-site/assets/66470099/fe096782-34a0-4b2e-9f51-f833d3b15695)

# After

![Screenshot 2023-09-19 074147](https://github.com/defencedigital/moduk-frontend-guidance-site/assets/66470099/f2b73dee-2d94-4dc0-a7a8-fd88d6065041)

