### PR TITLE
fix(build on d2s): Replace eleventy hashing algorithm

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -18,10 +18,14 @@ const postcssPresetEnv = require('postcss-preset-env')
 const prettier = require('@prettier/sync')
 const webpack = require('webpack')
 const { createNunjucksEnvironment, getNunjucksPaths } = require('@moduk/frontend')
-
+const crypto = require('node:crypto')
 const webpackConfig = require('./webpack.config')
 
 const templatePath = join(__dirname, 'src/site/_includes')
+
+// HACK: OpenSSL 3 does not support md5 any more, but eleventy-plugin-rev hardcodes it
+const cryptoOriginalCreateHash = crypto.createHash
+crypto.createHash = (algorithm) => cryptoOriginalCreateHash(algorithm === 'md5' ? 'sha256' : algorithm)
 
 module.exports = (config) => {
   config.addPlugin(revPlugin)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app-build
 
 COPY package.json /app-build/
 COPY package-lock.json /app-build/
-RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 && NODE_OPTIONS=--openssl-legacy-provider && npm ci
+RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 && npm ci
 
 COPY . /app-build
 RUN npm run build


### PR DESCRIPTION
`eleventy-plugin-rev` hardcodes the `md5` hashing algorithm, but this is not supported by OpenSSL3