### PR TITLE
build: Update base images to UBI9

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -3,7 +3,7 @@ description: Sets up Node.js and installs dependencies
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         cache: npm
         node-version-file: .nvmrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM registry.access.redhat.com/ubi8/nodejs-18:1-114 AS builder
+FROM registry.access.redhat.com/ubi9/nodejs-18@sha256:ffbad8210aee178157e7621b5fa43fb85f1ac205246b0d2606bea778549da8c1 AS builder
 
 USER root
 WORKDIR /app-build
@@ -13,7 +13,7 @@ COPY . /app-build
 RUN npm run build
 
 # Copy to the RedHat Nginx image
-FROM registry.access.redhat.com/ubi8/nginx-120:1-137
+FROM registry.access.redhat.com/ubi9/nginx-120@sha256:7780f65bb941e76560b5f6870d2bb1f6c65305c6ef56e573ed6dfafe61ded3ef
 
 RUN rm -r "${HOME}/nginx-start/"
 


### PR DESCRIPTION
The Dockerfile build was failing due to too many open files. Updating the base images to use UBI9 fixes this.